### PR TITLE
Add lib/rubocop-no_keyword_args.rb

### DIFF
--- a/lib/rubocop-no_keyword_args.rb
+++ b/lib/rubocop-no_keyword_args.rb
@@ -1,0 +1,1 @@
+require 'rubocop/no_keyword_args'


### PR DESCRIPTION
Rubocopのドキュメントの例にあるようにrubocopのextensionは `/` ではなくてハイフン区切りでrequireできるようになっている
https://rubocop.readthedocs.io/en/stable/extensions/#loading-extensions

例えばrubocop-performance, rubocop-rails, rubocop-rspec等
https://github.com/rubocop-hq/rubocop-performance/blob/master/lib/rubocop-performance.rb
https://github.com/rubocop-hq/rubocop-rails/blob/master/lib/rubocop-rails.rb
https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop-rspec.rb

↑に習って.rubocop.ymlの中で `rubocop-no_keyword_args` と書いてもrequireできるようにしたい

```yml
require:
  - rubocop-no_keyword_args
  - rubocop-performance
  - rubocop-rails
  - rubocop-rspec
```